### PR TITLE
Added support for SameSite session cookie attribute

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -21,6 +21,8 @@ type Config struct {
 	HTTPOnly bool
 	// cookie may only be transferred over HTTPS
 	Secure bool
+	// Controls SameSite attribute for session cookie
+	SameSite http.SameSite
 }
 
 // Session represents Values state which  a named bundle of maintained web state

--- a/store.go
+++ b/store.go
@@ -32,6 +32,7 @@ func NewCookieStore(keyPairs ...[]byte) *CookieStore {
 			Path:     "/",
 			MaxAge:   defaultMaxAge,
 			HTTPOnly: true,
+			SameSite: http.SameSiteDefaultMode,
 		},
 	}
 }
@@ -86,6 +87,7 @@ func newCookie(name, value string, config *Config) *http.Cookie {
 		MaxAge:   config.MaxAge,
 		HttpOnly: config.HTTPOnly,
 		Secure:   config.Secure,
+		SameSite: config.SameSite,
 	}
 	// IE <9 does not understand MaxAge, set Expires based on MaxAge
 	if expires, present := cookieExpires(config.MaxAge); present {


### PR DESCRIPTION
@dghubble Hey there, thanks for a useful little package. I wanted to use the new SameSite cookie attribute on my session cookies, so added support for that. 

Now, when I use the package, I do a `var sessionStore = sessions.NewCookieStore()` and then inside my own package's init() function I do e.g. `sessionStore.Config.SameSite = http.SameSiteLaxMode`, which means all the session cookies I create after that will have lax mode enabled.

Blog article about SameSite: https://scotthelme.co.uk/csrf-is-dead/

cheers

  /Ragnar