### PR TITLE
Update Go tests and add dependabot

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.14', '1.15', '1.16']
+        go: ['1.16', '1.17']
     steps:
       - name: setup
         uses: actions/setup-go@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.2.0
+
+* Fix `go.mod` to include `gorilla/securecookie` ([#7](https://github.com/dghubble/sessions/pull/7))
+
 ## v0.1.0
 
 * Initial release

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dghubble/sessions
 
-go 1.14
+go 1.16
 
 require github.com/gorilla/securecookie v1.1.1


### PR DESCRIPTION
* Use dependabot to watch for Go module updates
* Update Go version in go.mod
* Update Go versions in Github Actions matrix