### PR TITLE
Change Session Values field to be non-exported

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+* Change the `Session` field `Values` to be non-exported ([#18](https://github.com/dghubble/sessions/pull/18))
+  * Add `Session` `Set` method to set a key/value pair
+  * Add `Session` `Get` method to get a value for a given key
+  * Add `Session` `GetOk` to get a value for a given key and whether
+the key exists in the map
 * Remove cookie `Config` field from `Session` ([#17](https://github.com/dghubble/sessions/pull/17))
 
 ## v0.2.1

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func (s server) Login() http.Handler {
     // create a session
     session := s.sessions.New("my-app")
     // add user-id to session
-    session.Values["user-id"] = 123
+    session.Set("user-id", 123)
     // save the session to the response
     if err := session.Save(w); err != nil {
       // handle error
@@ -76,7 +76,7 @@ func (s server) RequireLogin() http.Handler {
       return
     }
 
-    userID := session.Values("user-id")
+    userID := session.Get("user-id")
     fmt.Fprintf(w, `<p>Welcome %d!</p>
     <form action="/logout" method="post">
     <input type="submit" value="Logout">

--- a/sessions.go
+++ b/sessions.go
@@ -8,11 +8,10 @@ const (
 	defaultMaxAge = 3600 * 24 * 7 // 1 week
 )
 
-// Session represents Values state which  a named bundle of maintained web state
-// stores web session state
+// Session represents state values maintained in a sessions Store.
 type Session struct {
-	name   string // session cookie name
-	Values map[string]interface{}
+	name   string
+	values map[string]any
 	// convenience methods Save and Destroy use store
 	store Store
 }
@@ -20,15 +19,31 @@ type Session struct {
 // NewSession returns a new Session.
 func NewSession(store Store, name string) *Session {
 	return &Session{
-		store:  store,
 		name:   name,
-		Values: make(map[string]interface{}),
+		values: make(map[string]any),
+		store:  store,
 	}
 }
 
 // Name returns the name of the session.
 func (s *Session) Name() string {
 	return s.name
+}
+
+// Set sets a key/value pair in the session state.
+func (s *Session) Set(key string, value any) {
+	s.values[key] = value
+}
+
+// Get returns the state value for the given key.
+func (s *Session) Get(key string) any {
+	return s.values[key]
+}
+
+// GetOk returns the state value for the given key and whether they key exists.
+func (s *Session) GetOk(key string) (any, bool) {
+	value, ok := s.values[key]
+	return value, ok
 }
 
 // Save adds or updates the session. Identical to calling

--- a/store.go
+++ b/store.go
@@ -50,7 +50,7 @@ func (s *CookieStore) Get(req *http.Request, name string) (session *Session, err
 	cookie, err := req.Cookie(name)
 	if err == nil {
 		session = s.New(name)
-		err = securecookie.DecodeMulti(name, cookie.Value, &session.Values, s.Codecs...)
+		err = securecookie.DecodeMulti(name, cookie.Value, &session.values, s.Codecs...)
 	}
 	return session, err
 }
@@ -59,7 +59,7 @@ func (s *CookieStore) Get(req *http.Request, name string) (session *Session, err
 // encrypted session cookie. Session Values are encoded into the cookie value
 // and the session Config sets cookie properties.
 func (s *CookieStore) Save(w http.ResponseWriter, session *Session) error {
-	cookieValue, err := securecookie.EncodeMulti(session.Name(), &session.Values, s.Codecs...)
+	cookieValue, err := securecookie.EncodeMulti(session.Name(), &session.values, s.Codecs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Add Session methods to access session state key/value pairs
* Use Session Set to set a key/value pair
* Use Session Get to get a value for a given key
* Use Session GetOk to get a value for a given key and whether the key exists in the map

```diff
// add user-id to session
- session.Values["user-id"] = 123
+ session.Set("user-id", 123)

// get user-id from session
- userID := session.Values("user-id")
+ userID := session.Get("user-id")
```