### PR TITLE
Change DefaultCookieConfig to use the SameSiteLaxMode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,6 @@ Notable changes between releases.
 
 ## Latest
 
-* Allow `Session` to store values with specified type (`V`) (i.e. generics) ([#22](https://github.com/dghubble/sessions/pull/21))
-  * `Session` state is now a `map[string]V` instead of a `map[string]any`
-  * Update `Set`, `Get`, and `GetOk` methods to use generic type `V`
-  * Change `Session` to `Session[V any]` to specify the type of value stored in the Session
-  * See updated usage docs for examples
-* Change `Store` to `Store[V any]` to specify the type of value stored in sessions
-* Change `NewCookieStore` to `NewCookieStore[V any]` to specify the type of value stored in sessions
-
 ## v0.3.0
 
 * Change `CookieStore` and its fields to be non-exported ([#19](https://github.com/dghubble/sessions/pull/19))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.3.1
+
+* Change `DefaultCookieConfig` to use `SameSiteLaxMode` ([#22](https://github.com/dghubble/sessions/pull/22))
+
 ## v0.3.0
 
 * Change `CookieStore` and its fields to be non-exported ([#19](https://github.com/dghubble/sessions/pull/19))

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Read [GoDoc](https://godoc.org/github.com/dghubble/sessions)
 
 Create a `Store` for managing `Session`'s. `NewCookieStore` returns a `Store` that signs and optionally encrypts cookies to support user sessions.
 
-A `Session` stores a map of key/value pairs (e.g. "userID": "a1b2c3"). Starting with v0.4.0, `sessions` uses Go generics to allow specifying a type for stored values.Previously, values were type `interface{}` or `any`, which required type assertions.
-
 ```go
 import (
   "github.com/dghubble/sessions"
@@ -33,7 +31,7 @@ import (
 func NewServer() (http.Handler) {
   ...
   // client-side cookies
-  store := sessions.NewCookieStore[string](
+  sessionProvider := sessions.NewCookieStore(
     sessions.DefaultCookieConfig,
     // use a 32 byte or 64 byte hash key
     []byte("signing-secret"),
@@ -41,7 +39,6 @@ func NewServer() (http.Handler) {
     []byte("encryption-secret")
   )
   ...
-  server.sessions = store
 }
 ```
 
@@ -53,7 +50,7 @@ func (s server) Login() http.Handler {
     // create a session
     session := s.sessions.New("my-app")
     // add user-id to session
-    session.Set("user-id", "a1b2c3")
+    session.Set("user-id", 123)
     // save the session to the response
     if err := session.Save(w); err != nil {
       // handle error
@@ -75,12 +72,7 @@ func (s server) RequireLogin() http.Handler {
       return
     }
 
-    userID, present := session.GetOk("user-id")
-    if !present {
-      http.Error(w, "missing user-id", http.StatusUnauthorized)
-      return
-    }
-
+    userID := session.Get("user-id")
     fmt.Fprintf(w, `<p>Welcome %d!</p>
     <form action="/logout" method="post">
     <input type="submit" value="Logout">

--- a/cookie.go
+++ b/cookie.go
@@ -11,7 +11,7 @@ var DefaultCookieConfig = &CookieConfig{
 	MaxAge:   defaultMaxAge,
 	HTTPOnly: true,
 	Secure:   true,
-	SameSite: http.SameSiteStrictMode,
+	SameSite: http.SameSiteLaxMode,
 }
 
 // DebugCookieConfig configures http.Cookie creation for debugging. It

--- a/sessions.go
+++ b/sessions.go
@@ -9,51 +9,51 @@ const (
 )
 
 // Session represents state values maintained in a sessions Store.
-type Session[V any] struct {
+type Session struct {
 	name   string
-	values map[string]V
+	values map[string]any
 	// convenience methods Save and Destroy use store
-	store Store[V]
+	store Store
 }
 
 // NewSession returns a new Session.
-func NewSession[V any](store Store[V], name string) *Session[V] {
-	return &Session[V]{
+func NewSession(store Store, name string) *Session {
+	return &Session{
 		name:   name,
-		values: make(map[string]V),
+		values: make(map[string]any),
 		store:  store,
 	}
 }
 
 // Name returns the name of the session.
-func (s *Session[V]) Name() string {
+func (s *Session) Name() string {
 	return s.name
 }
 
 // Set sets a key/value pair in the session state.
-func (s *Session[V]) Set(key string, value V) {
+func (s *Session) Set(key string, value any) {
 	s.values[key] = value
 }
 
 // Get returns the state value for the given key.
-func (s *Session[V]) Get(key string) V {
+func (s *Session) Get(key string) any {
 	return s.values[key]
 }
 
 // GetOk returns the state value for the given key and whether they key exists.
-func (s *Session[V]) GetOk(key string) (V, bool) {
+func (s *Session) GetOk(key string) (any, bool) {
 	value, ok := s.values[key]
 	return value, ok
 }
 
 // Save adds or updates the session. Identical to calling
 // store.Save(w, session).
-func (s *Session[V]) Save(w http.ResponseWriter) error {
+func (s *Session) Save(w http.ResponseWriter) error {
 	return s.store.Save(w, s)
 }
 
 // Destroy destroys the session. Identical to calling
 // store.Destroy(w, session.name).
-func (s *Session[V]) Destroy(w http.ResponseWriter) {
+func (s *Session) Destroy(w http.ResponseWriter) {
 	s.store.Destroy(w, s.name)
 }

--- a/store.go
+++ b/store.go
@@ -7,21 +7,19 @@ import (
 )
 
 // A Store manages creating, accessing, writing, and expiring Sessions.
-type Store[V any] interface {
+type Store interface {
 	// New returns a new named Session
-	New(name string) *Session[V]
+	New(name string) *Session
 	// Get a named Session from the request
-	Get(req *http.Request, name string) (*Session[V], error)
+	Get(req *http.Request, name string) (*Session, error)
 	// Save writes a Session to the ResponseWriter
-	Save(w http.ResponseWriter, session *Session[V]) error
+	Save(w http.ResponseWriter, session *Session) error
 	// Destroy removes (expires) a named Session
 	Destroy(w http.ResponseWriter, name string)
 }
 
-var _ Store[any] = &cookieStore[any]{}
-
 // CookieStore stores Sessions in secure cookies (i.e. client-side)
-type cookieStore[V any] struct {
+type cookieStore struct {
 	config *CookieConfig
 	// encodes and decodes signed and optionally encrypted cookie values
 	codecs []securecookie.Codec
@@ -29,26 +27,26 @@ type cookieStore[V any] struct {
 
 // NewCookieStore returns a new Store that signs and optionally encrypts
 // session state in http cookies.
-func NewCookieStore[V any](config *CookieConfig, keyPairs ...[]byte) Store[V] {
+func NewCookieStore(config *CookieConfig, keyPairs ...[]byte) Store {
 	if config == nil {
 		config = DefaultCookieConfig
 	}
 
-	return &cookieStore[V]{
+	return &cookieStore{
 		config: config,
 		codecs: securecookie.CodecsFromPairs(keyPairs...),
 	}
 }
 
 // New returns a new named Session.
-func (s *cookieStore[V]) New(name string) *Session[V] {
-	return NewSession[V](s, name)
+func (s *cookieStore) New(name string) *Session {
+	return NewSession(s, name)
 }
 
 // Get returns the named Session from the Request. Returns an error if the
 // session cookie cannot be found, the cookie verification fails, or an error
 // occurs decoding the cookie value.
-func (s *cookieStore[V]) Get(req *http.Request, name string) (session *Session[V], err error) {
+func (s *cookieStore) Get(req *http.Request, name string) (session *Session, err error) {
 	cookie, err := req.Cookie(name)
 	if err == nil {
 		session = s.New(name)
@@ -60,7 +58,7 @@ func (s *cookieStore[V]) Get(req *http.Request, name string) (session *Session[V
 // Save adds or updates the Session on the response via a signed and optionally
 // encrypted session cookie. Session Values are encoded into the cookie value
 // and the session Config sets cookie properties.
-func (s *cookieStore[V]) Save(w http.ResponseWriter, session *Session[V]) error {
+func (s *cookieStore) Save(w http.ResponseWriter, session *Session) error {
 	cookieValue, err := securecookie.EncodeMulti(session.Name(), &session.values, s.codecs...)
 	if err != nil {
 		return err
@@ -71,6 +69,6 @@ func (s *cookieStore[V]) Save(w http.ResponseWriter, session *Session[V]) error 
 
 // Destroy deletes the Session with the given name by issuing an expired
 // session cookie with the same name.
-func (s *cookieStore[V]) Destroy(w http.ResponseWriter, name string) {
+func (s *cookieStore) Destroy(w http.ResponseWriter, name string) {
 	http.SetCookie(w, newCookie(name, "", &CookieConfig{MaxAge: -1, Path: s.config.Path}))
 }


### PR DESCRIPTION
* Redirecting to a provider's AuthURL as part of Login creates a chain of redirects to the configured backend callback handler to set a session cookie and (typically) redirect to a profile page
* Strict cookies would not be sent in the request to the profile page because the redirect chain originated with a redirect to the login provider. The original referrer is used throughout the redirect chain. Because of this browser behavior, most users will need to use SameSite lax mode

If you understand the implications, you can still set strict mode:

```
cookieConfig := sessions.DefaultCookieConfig
cookieConfig.SameSite = http.SameSiteStrictMode
```

Rel:

* https://www.nogginbox.co.uk/blog/strict-cookies-not-sent-by-request
* https://bugzilla.mozilla.org/show_bug.cgi?id=1453814