### PR TITLE
Use a centrally managed GitHub Workflow for go tests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,25 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - main
-  pull_request:
 jobs:
-  build:
-    name: go
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.18', '1.19']
-    steps:
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{matrix.go}}
-
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: test
-        run: make
+  go:
+    uses: dghubble/.github/.github/workflows/golang-library.yaml@main


### PR DESCRIPTION
* Use GitHub Workflow from https://github.com/dghubble/.github
* Test against Go v1.19 and v1.20